### PR TITLE
PC-001: The Alphabet update

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -381,6 +381,7 @@
   height: 25px;
   transition-duration: 0.2s;
   margin: 1%;
+  text-align: center;
 }
 
 .textInput {
@@ -431,6 +432,21 @@
   font-size: x-large;
   text-align: center;
   vertical-align: middle;
+}
+
+.charAdd {
+  padding: 0%;
+  margin: 1%;
+  width: 25px;
+  height: 25px;
+  border-color: transparent;
+  color: var(--text-colour-secondary);
+  background-color: transparent;
+  transition-duration: 0.2s;
+  font-weight: 700;
+  font-size: large;
+  text-align: center;
+  vertical-align: top;
 }
 
 .txtTransitionsWrapper, .txtStatesWrapper, #txtAlphabetWrapper {
@@ -507,6 +523,8 @@
   background-color: var(--back-colour-secondary);
   color: var(--text-colour-secondary);
   text-align: left;
+  height: 30px;
+  line-height: 30px;
   vertical-align: middle;
   transition: all 0.2s ease-in;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -101,6 +101,11 @@
   background-color: var(--back-colour-primary-2)
 }
 
+.bookendWrapper {
+  display: flex;
+  flex-flow: row;
+}
+
 .simState {
   display: flex;
   flex-flow: column;
@@ -336,14 +341,14 @@
   position: absolute;
   display: flex;
   flex-direction: row;
-  height: calc(100vh - 150px);
+  height: calc(100vh - 196px);
 }
 
 #optionsWrapper {
   position: absolute;
   display: flex;
   flex-direction: row;
-  height: calc(100vh - 150px);
+  height: calc(100vh - 196px);
   right: 0;
 }
 
@@ -428,10 +433,10 @@
   vertical-align: middle;
 }
 
-.txtTransitionsWrapper, .txtStatesWrapper {
+.txtTransitionsWrapper, .txtStatesWrapper, #txtAlphabetWrapper {
   position: relative;
   width: 300px;
-  height: 50%;
+  height: 34%;
   border-bottom: solid;
   border-left: solid;
   border-right: solid;
@@ -484,11 +489,8 @@
   background-color: var(--back-colour-primary-1);
 }
 
-.transition {
+.txtState, .transition {
   border-radius: 25px;
-  border-style: solid;
-  border-width: 1px;
-  border-color: var(--border-colour);
   margin: 5px;
   height: 31px;
   opacity: 1;
@@ -497,15 +499,25 @@
   transition: all 0.2s ease-in;
 }
 
-.txtState {
+.alphabet {
   border-radius: 25px;
-  border-style: solid;
-  border-width: 1px;
-  border-color: transparent;
   margin: 5px;
-  height: 31px;
+  padding: 10px;
   opacity: 1;
   background-color: var(--back-colour-secondary);
+  color: var(--text-colour-secondary);
+  text-align: left;
+  vertical-align: middle;
+  transition: all 0.2s ease-in;
+}
+
+.bookendInput {
+  border-radius: 25px;
+  margin: 5px;
+  width: 50%;
+  opacity: 1;
+  background-color: var(--back-colour-secondary);
+  color: var(--text-colour-secondary);
   vertical-align: middle;
   transition: all 0.2s ease-in;
 }
@@ -554,7 +566,7 @@
   white-space: nowrap;
 }
 
-.txtTransitionHeader, .txtStatesHeader {
+.txtTransitionHeader, .txtStatesHeader, .txtAlphabetHeader {
   text-align: left;
   padding: 0;
   margin: 10px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -183,11 +183,13 @@ function App() {
     } else if (char.length === 0) {
       typeParam = 'remove'
     }
+    console.log(alphabet)
     alphabetDispatch({
       type: typeParam,
       id: id,
       params: { char, index }
-  })
+    })
+    console.log(alphabet)
   }
 
   const clientSimRun = () => {
@@ -448,24 +450,26 @@ useEffect(() => {
           onAlternateUpdate={(id: number, value: boolean) => {clientUpdateAlternating(id, value)}}
           onAddState={() => {clientAddState()}}
           onAlphabetUpdate={(id: string, char: string, index: number) => {clientAlphabetUpdate(id, char, index)}}/>
-            <OptionWrapper
-              colour={colour}
-            />
-            <SimWrapper
-              colour={colour}
-              input={input}
-              stacks={stacks}
-              currentTraversals={currentTraversal}
-              states={states}
-              haltCond={options['haltCondition'].value}
-              onInputUpdate={(value: string) => {setInput(value)}}
-              onRun={() => {clientSimRun()}}
-              onStep={() => {clientSimStep()}}
-              onReset={() => {reset()}}
-              setSelected={(value: number) => {setSelectedTraversal(value)}}
-            />
-          </OptionDispatchContext.Provider>
-        </OptionContext.Provider>
+      <OptionWrapper
+        onAlphabetUpdate={(id: string, char: string, index: number) => {clientAlphabetUpdate(id, char, index)}}
+        colour={colour}
+      />
+      <SimWrapper
+        colour={colour}
+        input={input}
+        stacks={stacks}
+        currentTraversals={currentTraversal}
+        states={states}
+        haltCond={options['haltCondition'].value}
+        alphabet={alphabet}
+        onInputUpdate={(value: string) => {setInput(value)}}
+        onRun={() => {clientSimRun()}}
+        onStep={() => {clientSimStep()}}
+        onReset={() => {reset()}}
+        setSelected={(value: number) => {setSelectedTraversal(value)}}
+      />
+      </OptionDispatchContext.Provider>
+      </OptionContext.Provider>
     </div>
     </>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,9 @@ import { MotionPathPlugin } from "gsap/MotionPathPlugin";
 import { OptionWrapper } from './options/Wrapper';
 import DefaultOptions from './lib/DefaultOptions';
 import optionsReducer from './lib/OptionsReducer';
-import { OptionContext, OptionDispatchContext } from './lib/OptionsContext';
+import { OptionContext, OptionDispatchContext, AlphabetContext, AlphabetDispatchContext } from './lib/OptionsContext';
+import alphabetReducer from './lib/AlphabetReducer';
+import DefaultAlphabet from './lib/DefaultAlphabet';
 gsap.registerPlugin(MotionPathPlugin);
 
 
@@ -32,8 +34,10 @@ function App() {
   const [defaultTraversal, setDefaultTraversal] = useState<Traversal>({id: 0, history: [-1], stateId: 0, transitionId: -1, stack: stacks, inputHead: options['bookendInput'].value ? 1 : 0, end: 0})
   const [traversal, setTraversal] = useState<Traversal[]>([defaultTraversal])
   const [colour, setColour] = useState<string>('light')
-  const [alphabet, setAlphabet] = useState<Alphabet>({startChar:'S', endChar:'E', callChars:[], returnChars:[], internalChars:[], miscChars:['0', '1'], allChars:['S', 'E', '0', '1']})
+
+  //const [alphabet, setAlphabet] = useState<Alphabet>({startChar:'S', endChar:'E', callChars:[], returnChars:[], internalChars:[], miscChars:['0', '1'], allChars:['S', 'E', '0', '1']})
   
+  const [alphabet, alphabetDispatch] = useReducer(alphabetReducer, DefaultAlphabet)
   const stackCountMax = 2
 
   const arrayEqual = (a: any[], b: any[]): boolean => {
@@ -172,73 +176,18 @@ function App() {
     setStates(newStates)
   }
 
-  const clientAlphabetUpdate = (type: number, char: string, index: number) => {
-    let newAlphabet = alphabet
-    let newIndex = 0
-
-    if (newAlphabet.allChars.find((a, i) => {return (a === char && i != index)}) === char) {
-      console.log("The alphabet must be a distinct set, no duplicates allowed")
-      return
+  const clientAlphabetUpdate = (id: string, char: string, index: number) => {
+    let typeParam = 'update'
+    if (index === -1) {
+      typeParam = 'add'
+    } else if (char.length === 0) {
+      typeParam = 'remove'
     }
-
-    switch (type) {
-      case 0:
-        newIndex = index - 2
-        if (char.length === 0) {
-          newAlphabet.miscChars = newAlphabet.miscChars.filter(c => c !== newAlphabet.miscChars[newIndex])
-        } else {
-          newAlphabet.miscChars[newIndex] = char
-        }
-        break;
-      case 1:
-        newIndex = index - (2 + newAlphabet.miscChars.length)
-        if (char.length === 0) {
-          newAlphabet.callChars = newAlphabet.callChars.filter(c => c !== newAlphabet.callChars[newIndex])
-        } else {
-          newAlphabet.callChars[newIndex] = char
-        }
-        break;
-      case 2:
-        newIndex = index - (2 + newAlphabet.miscChars.length + newAlphabet.callChars.length)
-        if (char.length === 0) {
-          newAlphabet.returnChars = newAlphabet.returnChars.filter(c => c !== newAlphabet.returnChars[newIndex])
-        } else {
-          newAlphabet.returnChars[newIndex] = char
-        }
-        break;
-      case 3:
-        newIndex = index - (2 + newAlphabet.miscChars.length + newAlphabet.callChars.length + newAlphabet.returnChars.length)
-        if (char.length === 0) {
-          newAlphabet.internalChars = newAlphabet.internalChars.filter(c => c !== newAlphabet.internalChars[newIndex])
-        } else {
-          newAlphabet.internalChars[newIndex] = char
-        }
-        break;
-      case 4:
-        if (char.length === 0) {
-          console.log("The front char cannot be empty")
-          return
-        } else {
-          newAlphabet.startChar = char
-        }
-        
-        break;
-      case 5:
-        if (char.length === 0) {
-          console.log("The end char cannot be empty")
-          return
-        } else {
-          newAlphabet.endChar = char
-        }
-        break;
-    
-      default:
-        break;
-    }
-    newAlphabet.allChars[index] = char
-
-    console.log(newAlphabet)
-    setAlphabet(newAlphabet)
+    alphabetDispatch({
+      type: typeParam,
+      id: id,
+      params: { char, index }
+  })
   }
 
   const clientSimRun = () => {
@@ -497,7 +446,7 @@ useEffect(() => {
           onAcceptUpdate={(id: number, value: boolean) => {clientUpdateAccepting(id, value)}}
           onAlternateUpdate={(id: number, value: boolean) => {clientUpdateAlternating(id, value)}}
           onAddState={() => {clientAddState()}}
-          onAlphabetUpdate={(type: number, char: string, index: number) => {clientAlphabetUpdate(type, char, index)}}/>
+          onAlphabetUpdate={(id: string, char: string, index: number) => {clientAlphabetUpdate(id, char, index)}}/>
             <OptionWrapper
               colour={colour}
             />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -407,6 +407,7 @@ useEffect(() => {
           scale={scale}
           stackCount={options['stackCount'].value}
           interactMode={interactMode}
+          alphabet={alphabet}
           onStatePosUpdate={(id: number, x: number, y: number) => {clientGuiUpdateStatePos(id, x, y)}}
           onScaleUpdate={(value: number) => {setScale(value)}}
           onPosUpdate={(value: {x: number, y: number}) => setPos(value)}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -174,31 +174,68 @@ function App() {
 
   const clientAlphabetUpdate = (type: number, char: string, index: number) => {
     let newAlphabet = alphabet
+    let newIndex = 0
 
-    newAlphabet.allChars[index] = char
+    if (newAlphabet.allChars.find((a, i) => {return (a === char && i != index)}) === char) {
+      console.log("The alphabet must be a distinct set, no duplicates allowed")
+      return
+    }
+
     switch (type) {
       case 0:
-        newAlphabet.miscChars[index - 2] = char
+        newIndex = index - 2
+        if (char.length === 0) {
+          newAlphabet.miscChars = newAlphabet.miscChars.filter(c => c !== newAlphabet.miscChars[newIndex])
+        } else {
+          newAlphabet.miscChars[newIndex] = char
+        }
         break;
       case 1:
-        newAlphabet.callChars[index - (2 + newAlphabet.miscChars.length)] = char
+        newIndex = index - (2 + newAlphabet.miscChars.length)
+        if (char.length === 0) {
+          newAlphabet.callChars = newAlphabet.callChars.filter(c => c !== newAlphabet.callChars[newIndex])
+        } else {
+          newAlphabet.callChars[newIndex] = char
+        }
         break;
       case 2:
-        newAlphabet.returnChars[index - (2 + newAlphabet.miscChars.length + newAlphabet.callChars.length)] = char
+        newIndex = index - (2 + newAlphabet.miscChars.length + newAlphabet.callChars.length)
+        if (char.length === 0) {
+          newAlphabet.returnChars = newAlphabet.returnChars.filter(c => c !== newAlphabet.returnChars[newIndex])
+        } else {
+          newAlphabet.returnChars[newIndex] = char
+        }
         break;
       case 3:
-        newAlphabet.internalChars[index - (2 + newAlphabet.miscChars.length + newAlphabet.callChars.length + newAlphabet.returnChars.length)] = char
+        newIndex = index - (2 + newAlphabet.miscChars.length + newAlphabet.callChars.length + newAlphabet.returnChars.length)
+        if (char.length === 0) {
+          newAlphabet.internalChars = newAlphabet.internalChars.filter(c => c !== newAlphabet.internalChars[newIndex])
+        } else {
+          newAlphabet.internalChars[newIndex] = char
+        }
         break;
       case 4:
-        newAlphabet.startChar = char
+        if (char.length === 0) {
+          console.log("The front char cannot be empty")
+          return
+        } else {
+          newAlphabet.startChar = char
+        }
+        
         break;
       case 5:
-        newAlphabet.endChar = char
+        if (char.length === 0) {
+          console.log("The end char cannot be empty")
+          return
+        } else {
+          newAlphabet.endChar = char
+        }
         break;
     
       default:
         break;
     }
+    newAlphabet.allChars[index] = char
 
     console.log(newAlphabet)
     setAlphabet(newAlphabet)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,7 +79,7 @@ function App() {
   }
 
   const clientUpdateCInput = (transitionId: number, cInput: string) => {
-    let newTransitions = updateInput(transitionId, cInput, [...transitions], options['forceDeterministic'].value)
+    let newTransitions = updateInput(transitionId, cInput, [...transitions], options['forceDeterministic'].value, alphabet)
     setTransitions(newTransitions)
   }
 
@@ -121,8 +121,6 @@ function App() {
 
   const clientAddGuiTransition = (cState: State, nState: State) => {
     let newPA = tAdd([...transitions], [...states], stackCountMax, [...connections], cState.id, undefined, undefined, nState.id)
-    /* newPA = updateState(newPA.transitions[newPA.transitions.length - 1].id, cState.name, true, [...newPA.transitions], [...newPA.states], [...newPA.connections], options['forceDeterministic'].value) */
-    /* newPA = updateState(newPA.transitions[newPA.transitions.length - 1].id, nState.name, false, [...newPA.transitions], [...newPA.states], [...newPA.connections], options['forceDeterministic'].value) */
 
     setTransitions(newPA.transitions)
     setStates(newPA.states)
@@ -180,6 +178,8 @@ function App() {
     let typeParam = 'update'
     if (index === -1) {
       typeParam = 'add'
+    } else if (index === -2) {
+      typeParam = 'empty'
     } else if (char.length === 0) {
       typeParam = 'remove'
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useReducer, useState } from 'react';
 import './App.css';
-import { Connection, State, Transition, Traversal } from './types';
+import { Alphabet, Connection, State, Transition, Traversal } from './types';
 import { Wrapper as TxtWrapper } from './txt/wrapper';
 import { Wrapper as SimWrapper } from './sim/wrapper';
 import { add as tAdd, remove as tRemove, updateState, updateInputHead, updateStack, updateInput, findDuplicateTransition, findInvalidAlphabetUse } from './lib/transitions';
@@ -32,6 +32,7 @@ function App() {
   const [defaultTraversal, setDefaultTraversal] = useState<Traversal>({id: 0, history: [-1], stateId: 0, transitionId: -1, stack: stacks, inputHead: options['bookendInput'].value ? 1 : 0, end: 0})
   const [traversal, setTraversal] = useState<Traversal[]>([defaultTraversal])
   const [colour, setColour] = useState<string>('light')
+  const [alphabet, setAlphabet] = useState<Alphabet>({startChar:'S', endChar:'E', callChars:[], returnChars:[], internalChars:[], miscChars:['0', '1'], allChars:['S', 'E', '0', '1']})
   
   const stackCountMax = 2
 
@@ -169,6 +170,38 @@ function App() {
     let newStates = sAdd([...states])
     newStates = updatePosition(newStates[newStates.length - 1].id, x, y, [...newStates])
     setStates(newStates)
+  }
+
+  const clientAlphabetUpdate = (type: number, char: string, index: number) => {
+    let newAlphabet = alphabet
+
+    newAlphabet.allChars[index] = char
+    switch (type) {
+      case 0:
+        newAlphabet.miscChars[index - 2] = char
+        break;
+      case 1:
+        newAlphabet.callChars[index - (2 + newAlphabet.miscChars.length)] = char
+        break;
+      case 2:
+        newAlphabet.returnChars[index - (2 + newAlphabet.miscChars.length + newAlphabet.callChars.length)] = char
+        break;
+      case 3:
+        newAlphabet.internalChars[index - (2 + newAlphabet.miscChars.length + newAlphabet.callChars.length + newAlphabet.returnChars.length)] = char
+        break;
+      case 4:
+        newAlphabet.startChar = char
+        break;
+      case 5:
+        newAlphabet.endChar = char
+        break;
+    
+      default:
+        break;
+    }
+
+    console.log(newAlphabet)
+    setAlphabet(newAlphabet)
   }
 
   const clientSimRun = () => {
@@ -412,6 +445,7 @@ useEffect(() => {
           states={states}
           stackCount={options['stackCount'].value}
           colour={colour}
+          alphabet={alphabet}
           onRemoveTransition={(id: number) => {clientRemoveTransition(id)}}
           onCInputUpdate={(id: number, value: string) => {clientUpdateCInput(id, value)}}
           onCStateUpdate={(id: number, name: string) => {clientUpdateCState(id, name)}}
@@ -425,7 +459,8 @@ useEffect(() => {
           onInitUpdate={(id: number, value: boolean) => {clientUpdateInit(id, value)}}
           onAcceptUpdate={(id: number, value: boolean) => {clientUpdateAccepting(id, value)}}
           onAlternateUpdate={(id: number, value: boolean) => {clientUpdateAlternating(id, value)}}
-          onAddState={() => {clientAddState()}}/>
+          onAddState={() => {clientAddState()}}
+          onAlphabetUpdate={(type: number, char: string, index: number) => {clientAlphabetUpdate(type, char, index)}}/>
             <OptionWrapper
               colour={colour}
             />

--- a/src/contextMenu/transition.tsx
+++ b/src/contextMenu/transition.tsx
@@ -9,6 +9,7 @@ type CMTransitionProps = {
     transition: Transition,
     cState: string,
     nState: string,
+    alphabet: {[id: string]: string[]},
     onRemove: Function,
     onCInputUpdate: Function,
     onCStateUpdate: Function,
@@ -28,9 +29,8 @@ export const CMTransition = (props: CMTransitionProps) => {
     const options = useContext(OptionContext)
 
     const handleCInput= (e: any) => {
-        if (e.key === 'Enter') {
-            props.onCInputUpdate(props.transition.id, cInput)
-        }
+        props.onCInputUpdate(props.transition.id, e)
+        setCInput(e)
     }
 
     const handleCState = (e: any) => {
@@ -80,7 +80,14 @@ export const CMTransition = (props: CMTransitionProps) => {
     return (
         <div id='contextMenu' className={props.colour + ' contextMenu reveal'} style={{left: props.left, top: props.top}} >
             <div className={props.colour + ' contextMenuLabel'}>cState <input className={props.colour + ' contextMenuInput'} type='text' value={cState} onChange={(e) => setCState(e.currentTarget.value)} onKeyDown={(e) => handleCState(e)}/></div>
-            <div className={props.colour + ' contextMenuLabel'}>cInput <input className={props.colour + ' contextMenuInput'} type='text' value={cInput} maxLength={1} onChange={(e) => setCInput(e.currentTarget.value)} onKeyDown={(e) => handleCInput(e)}/></div>
+            <div className={props.colour + ' contextMenuLabel'}>
+                cInput 
+                <select className={props.colour + ' contextMenuInput'} value={cInput} onChange={(e) => handleCInput(e.currentTarget.value)} >
+                    {props.alphabet['allChar'].map((x, i) => {return(
+                        <option key={i} value={x}>{x}</option>
+                    )})}
+                </select>
+            </div>
             {props.transition.cStack.map((x, i) => {
                 if (i < options['stackCount'].value) {
                     return(<div key={i} className={props.colour + ' contextMenuLabel'}>{'cStack ' + String(i + 1)} <input className='contextMenuInput' type='text' value={cStack[i]}  maxLength={1} onChange={(e) => updateCStack(e.currentTarget.value, i)} onKeyDown={(e) => handleCStack(e, i)}/></div>)

--- a/src/contextMenu/transition.tsx
+++ b/src/contextMenu/transition.tsx
@@ -29,8 +29,10 @@ export const CMTransition = (props: CMTransitionProps) => {
     const options = useContext(OptionContext)
 
     const handleCInput= (e: any) => {
-        props.onCInputUpdate(props.transition.id, e)
-        setCInput(e)
+        if (e !== '') {
+            props.onCInputUpdate(props.transition.id, e)
+            setCInput(e)
+        }
     }
 
     const handleCState = (e: any) => {
@@ -83,6 +85,7 @@ export const CMTransition = (props: CMTransitionProps) => {
             <div className={props.colour + ' contextMenuLabel'}>
                 cInput 
                 <select className={props.colour + ' contextMenuInput'} value={cInput} onChange={(e) => handleCInput(e.currentTarget.value)} >
+                    <option key={-1} value={''}></option>
                     {props.alphabet['allChar'].map((x, i) => {return(
                         <option key={i} value={x}>{x}</option>
                     )})}

--- a/src/gui/wrapper.tsx
+++ b/src/gui/wrapper.tsx
@@ -18,6 +18,7 @@ type GuiWrapperProps = {
     stackCount: number,
     scale: number,
     interactMode: number,
+    alphabet: {[id: string]: string[]},
     onStatePosUpdate: Function,
     onScaleUpdate: Function,
     onPosUpdate: Function,
@@ -349,6 +350,7 @@ export const GuiWrapper = (props: GuiWrapperProps) => {
             transition={cmTransition}
             cState={states.find(s => s.id === cmTransition.cStateId)?.name ?? ''}
             nState={states.find(s => s.id === cmTransition.nStateId)?.name ?? ''}
+            alphabet={props.alphabet}
             onRemove={(id: number) => {props.onRemoveTransition(id)}}
             onCInputUpdate={(id: number, value: string) => {props.onCInputUpdate(id, value)}}
             onCStateUpdate={(id: number, name: string) => {props.onCStateUpdate(id, name)}}

--- a/src/gui/wrapper.tsx
+++ b/src/gui/wrapper.tsx
@@ -247,7 +247,7 @@ export const GuiWrapper = (props: GuiWrapperProps) => {
       let contextMenu = 1
       for (let index = 0; index < states.length; index++) {
         const state = states[index];
-        if (isPointInBox({x: evt.clientX, y: evt.clientY}, 'guiState' + state.id, boundary)) {
+        if (isPointInBox({x: evt.clientX, y: evt.clientY}, 'guiState' + state.id, boundary * scale)) {
           contextMenu = 2
           setCMState(state)
           break;

--- a/src/lib/AlphabetReducer.ts
+++ b/src/lib/AlphabetReducer.ts
@@ -8,7 +8,7 @@ const alphabetReducer = (alphabet: {[id: string]: string[]}, action: {type: stri
 
             if (typeof char === "string" && typeof index === "number") {
                 let duplicates = newAlphabet['allChar'].filter(c => {return (c === char)})
-                if ((char !== "" && duplicates.length > 0) || (char === "" && duplicates.length > 1)) {
+                if (duplicates.length > 0) {
                     console.log("Duplicate characters are not allowed")
                     return alphabet
                 }
@@ -44,6 +44,12 @@ const alphabetReducer = (alphabet: {[id: string]: string[]}, action: {type: stri
                 newAlphabet['allChar'][allIndex] = char
             }
 
+            return newAlphabet
+        }
+        case 'empty' : {
+            let newAlphabet = {...alphabet}
+            newAlphabet['allChar'] = newAlphabet['allChar'].filter(c => newAlphabet[action.id].indexOf(c) === undefined)
+            newAlphabet[action.id] = []
             return newAlphabet
         }
         default: {

--- a/src/lib/AlphabetReducer.ts
+++ b/src/lib/AlphabetReducer.ts
@@ -1,0 +1,58 @@
+
+const alphabetReducer = (alphabet: {[id: string]: string[]}, action: {type: string, id: string, params: any}) => {
+    console.log(alphabet)
+    switch (action.type) {
+        case 'add' : {
+            let newAlphabet = {...alphabet}
+            let { char, index } = action.params
+
+            if (typeof char === "string" && typeof index === "number") {
+                let duplicates = newAlphabet['allChar'].filter(c => {return (c === char)})
+                if (duplicates.length > 0) {
+                    console.log("Duplicate characters are not allowed")
+                    return alphabet
+                }
+                //console.log(action.id)
+                //console.log(newAlphabet[action.id])
+                newAlphabet[action.id].push('')
+                newAlphabet['allChar'].push('')
+                //console.log(newAlphabet[action.id])
+            }
+            return newAlphabet
+        }
+        case 'remove' : {
+            let newAlphabet = {...alphabet}
+            let { char, index } = action.params
+            if (typeof index === "number") {
+                let oldChar = newAlphabet[action.id][index]
+                newAlphabet[action.id] = newAlphabet[action.id].filter(c => c !== newAlphabet[action.id][index])
+                newAlphabet['allChar'] = [...newAlphabet['allChar'].filter(c => {return (c !== oldChar)})]
+            }
+
+            return newAlphabet
+        }
+        case 'update' : {
+            let newAlphabet = {...alphabet}
+            let { char, index } = action.params
+
+            if (typeof char === "string" && typeof index === "number") {
+                let duplicates = newAlphabet['allChar'].filter(c => {return (c === char)})
+                if (duplicates.length > 0) {
+                    console.log("Duplicate characters are not allowed")
+                    return alphabet
+                }
+                let oldChar = newAlphabet[action.id][index]
+                let allIndex = newAlphabet['allChar'].indexOf(oldChar)
+                newAlphabet[action.id][index] = char
+                newAlphabet['allChar'][allIndex] = char
+            }
+
+            return newAlphabet
+        }
+        default: {
+            throw Error('Unknown action: ' + action.type);
+        }
+    }
+}
+
+export default alphabetReducer

--- a/src/lib/AlphabetReducer.ts
+++ b/src/lib/AlphabetReducer.ts
@@ -8,15 +8,12 @@ const alphabetReducer = (alphabet: {[id: string]: string[]}, action: {type: stri
 
             if (typeof char === "string" && typeof index === "number") {
                 let duplicates = newAlphabet['allChar'].filter(c => {return (c === char)})
-                if (duplicates.length > 0) {
+                if (duplicates.length > 1) {
                     console.log("Duplicate characters are not allowed")
                     return alphabet
                 }
-                //console.log(action.id)
-                //console.log(newAlphabet[action.id])
                 newAlphabet[action.id].push('')
                 newAlphabet['allChar'].push('')
-                //console.log(newAlphabet[action.id])
             }
             return newAlphabet
         }

--- a/src/lib/AlphabetReducer.ts
+++ b/src/lib/AlphabetReducer.ts
@@ -1,6 +1,6 @@
 
 const alphabetReducer = (alphabet: {[id: string]: string[]}, action: {type: string, id: string, params: any}) => {
-    console.log(alphabet)
+    
     switch (action.type) {
         case 'add' : {
             let newAlphabet = {...alphabet}
@@ -8,12 +8,12 @@ const alphabetReducer = (alphabet: {[id: string]: string[]}, action: {type: stri
 
             if (typeof char === "string" && typeof index === "number") {
                 let duplicates = newAlphabet['allChar'].filter(c => {return (c === char)})
-                if (duplicates.length > 1) {
+                if ((char !== "" && duplicates.length > 0) || (char === "" && duplicates.length > 1)) {
                     console.log("Duplicate characters are not allowed")
                     return alphabet
                 }
-                newAlphabet[action.id].push('')
-                newAlphabet['allChar'].push('')
+                newAlphabet[action.id].push(char)
+                newAlphabet['allChar'].push(char)
             }
             return newAlphabet
         }

--- a/src/lib/DefaultAlphabet.ts
+++ b/src/lib/DefaultAlphabet.ts
@@ -1,0 +1,11 @@
+let DefaultAlphabet: {[id: string]: string[]} = {}
+
+DefaultAlphabet['startChar'] = []
+DefaultAlphabet['endChar'] = []
+DefaultAlphabet['miscChar'] = []
+DefaultAlphabet['callChar'] = []
+DefaultAlphabet['returnChar'] = []
+DefaultAlphabet['internalChar'] = []
+DefaultAlphabet['allChar'] = []
+
+export default DefaultAlphabet

--- a/src/lib/DefaultAlphabet.ts
+++ b/src/lib/DefaultAlphabet.ts
@@ -6,6 +6,6 @@ DefaultAlphabet['miscChar'] = []
 DefaultAlphabet['callChar'] = []
 DefaultAlphabet['returnChar'] = []
 DefaultAlphabet['internalChar'] = []
-DefaultAlphabet['allChar'] = ['']
+DefaultAlphabet['allChar'] = []
 
 export default DefaultAlphabet

--- a/src/lib/DefaultAlphabet.ts
+++ b/src/lib/DefaultAlphabet.ts
@@ -6,6 +6,6 @@ DefaultAlphabet['miscChar'] = []
 DefaultAlphabet['callChar'] = []
 DefaultAlphabet['returnChar'] = []
 DefaultAlphabet['internalChar'] = []
-DefaultAlphabet['allChar'] = []
+DefaultAlphabet['allChar'] = ['']
 
 export default DefaultAlphabet

--- a/src/lib/OptionsContext.ts
+++ b/src/lib/OptionsContext.ts
@@ -2,3 +2,5 @@ import { createContext } from "react";
 
 export const OptionContext = createContext<any>(null)
 export const OptionDispatchContext = createContext<any>(null)
+export const AlphabetContext = createContext<any>(null)
+export const AlphabetDispatchContext = createContext<any>(null)

--- a/src/lib/transitions.ts
+++ b/src/lib/transitions.ts
@@ -47,7 +47,7 @@ export const remove = (id: number, transitions: Transition[], states: State[], c
     return {states: states, transitions: transitions, connections: connections}
 }
 
-export const updateInput = (id: number, value: string, transitions: Transition[], deterministic: boolean): Transition[] => {
+export const updateInput = (id: number, value: string, transitions: Transition[], deterministic: boolean, alphabet: {[id: string]: string[]}): Transition[] => {
   let index = transitions.findIndex(t => t.id === id)
   
   if (index === -1) {
@@ -59,8 +59,17 @@ export const updateInput = (id: number, value: string, transitions: Transition[]
     if (deterministic && findDuplicateTransition(transitions[index], transitions).length > 0) {
       transitions[index].cInput = oldVal
     }
+    
+    if (alphabet['callChar'].indexOf(value) !== -1) {
+      transitions[index].nStack = Array(2).fill(value + transitions[index].cStack[0])
+    } else if (alphabet['returnChar'].indexOf(value) !== -1) {
+      transitions[index].nStack = Array(2).fill('')
+      console.log("return")
+    } else if (alphabet['internalChar'].indexOf(value) !== -1) {
+      transitions[index].nStack = Array(2).fill(value)
+    }
   }
-  
+  console.log(transitions[index])
   return transitions
 }
 

--- a/src/lib/transitions.ts
+++ b/src/lib/transitions.ts
@@ -143,7 +143,7 @@ export const updateInputHead = (id: number, value: number, transitions: Transiti
   return transitions
 }
 
-export const add = (transitions: Transition[], states: State[], stackCountMax: number, connections: Connection[], cStateId : number=0, cInput : string="0", cStack : string[]=["Z", "Z"], nStateId : number=0, nStack : string[]=["Z", "Z"], nInputHead : number=1): {states: State[], transitions: Transition[], connections: Connection[]} => {
+export const add = (transitions: Transition[], states: State[], stackCountMax: number, connections: Connection[], cStateId : number=0, cInput : string="", cStack : string[]=["Z", "Z"], nStateId : number=0, nStack : string[]=["Z", "Z"], nInputHead : number=1): {states: State[], transitions: Transition[], connections: Connection[]} => {
   
   if (states.length === 0) {
     states.push({id: 0, name: 'q0', initial: false, accepting: false, alternating: false, x: 0, y: 0})

--- a/src/options/Automaton.tsx
+++ b/src/options/Automaton.tsx
@@ -3,6 +3,7 @@ import '../App.css';
 import { OptionContext, OptionDispatchContext } from "../lib/OptionsContext";
 
 type AutomatonProps = {
+    onAlphabetUpdate: Function,
     colour: String
 }
 
@@ -46,6 +47,15 @@ export const Automaton = (props: AutomatonProps) => {
     }
 
     const handleForceVisibly = () => {
+
+        if (options['forceVisibly'].value) {
+            props.onAlphabetUpdate('callChar', '', -2)
+            props.onAlphabetUpdate('returnChar', '', -2)
+            props.onAlphabetUpdate('internalChar', '', -2)
+        } else {
+            props.onAlphabetUpdate('miscChar', '', -2)
+        }
+
         dispatch({
             type: 'set',
             id: 'forceVisibly',

--- a/src/options/Input.tsx
+++ b/src/options/Input.tsx
@@ -3,6 +3,7 @@ import '../App.css';
 import { OptionContext, OptionDispatchContext } from "../lib/OptionsContext";
 
 type InputProps = {
+    onAlphabetUpdate: Function,
     colour: String
 }
 
@@ -12,9 +13,6 @@ export const Input = (props: InputProps) => {
     const [to, setTo] = useState<NodeJS.Timeout>()
     const options = useContext(OptionContext)
     const dispatch = useContext(OptionDispatchContext)
-
-    const [fChar, setFChar] = useState<string>(options['inputFrontChar'].value)
-    const [eChar, setEChar] = useState<string>(options['inputEndChar'].value)
 
     const updateVisiblity = () => {
         if (!collapse) {
@@ -32,28 +30,16 @@ export const Input = (props: InputProps) => {
         setCollapse(!collapse)
     }
 
-    const handleInputFrontChar = (e: any) => {
-        if (e.key === 'Enter') {
-          
-            dispatch({
-                type: 'set',
-                id: 'inputFrontChar',
-                value: fChar
-            })
-        }
-    }
-
-    const handleInputEndChar = (e: any) => {
-        if (e.key === 'Enter') {
-            dispatch({
-                type: 'set',
-                id: 'inputEndChar',
-                value: eChar
-            })
-        }
-    }
-
     const handleBookendInput = () => {
+        
+        if (options['bookendInput'].value) {
+            props.onAlphabetUpdate('startChar', '', 0)
+            props.onAlphabetUpdate('endChar', '', 0)
+        } else {
+            props.onAlphabetUpdate('startChar', '[', -1)
+            props.onAlphabetUpdate('endChar', ']', -1)
+        }
+        
         dispatch({
             type: 'set',
             id: 'bookendInput',
@@ -68,12 +54,6 @@ export const Input = (props: InputProps) => {
             <div id='inputOptionList' className={props.colour + ' options close'}>
                 <div id='bookendWrapper'>
                     Bookend Input <input type='checkbox' checked={options['bookendInput'].value} onClick={handleBookendInput} />
-                </div>
-                <div id='frontCharWrapper'>
-                    Front Char <input className={props.colour + ' optionsBoxInput'} type='text' max={1} value={fChar} onChange={(x) => {setFChar(x.currentTarget.value)}} onKeyDown={(e) => handleInputFrontChar(e)}/>
-                </div>
-                <div id='endCharWrapper'>
-                    End Char <input className={props.colour + ' optionsBoxInput'} type='text' max={1} value={eChar} onChange={(x) => {setEChar(x.currentTarget.value)}} onKeyDown={(e) => handleInputEndChar(e)}/>
                 </div>
             </div>}
         </div>

--- a/src/options/Wrapper.tsx
+++ b/src/options/Wrapper.tsx
@@ -8,6 +8,7 @@ import { Stack } from './Stack'
 import '../App.css';
 
 type OptionWrapperProps = {
+    onAlphabetUpdate: Function,
     colour: String
 }
 
@@ -38,7 +39,7 @@ export const OptionWrapper = (props: OptionWrapperProps) => {
                 <div id='optionsInternalWrapper' className={props.colour + ' slideLeft'}>
                     <Animation colour={props.colour}/>
                     <Automaton colour={props.colour}/>
-                    <Input colour={props.colour}/>
+                    <Input onAlphabetUpdate={(id: string, char: string, index: number) => {props.onAlphabetUpdate(id, char, index)}} colour={props.colour}/>
                     <Stack colour={props.colour}/>
                     <Visual colour={props.colour}/>
                     <h1 className={props.colour + ' optionFooter'}/>

--- a/src/options/Wrapper.tsx
+++ b/src/options/Wrapper.tsx
@@ -38,7 +38,7 @@ export const OptionWrapper = (props: OptionWrapperProps) => {
             { render ? (
                 <div id='optionsInternalWrapper' className={props.colour + ' slideLeft'}>
                     <Animation colour={props.colour}/>
-                    <Automaton colour={props.colour}/>
+                    <Automaton onAlphabetUpdate={(id: string, char: string, index: number) => {props.onAlphabetUpdate(id, char, index)}} colour={props.colour}/>
                     <Input onAlphabetUpdate={(id: string, char: string, index: number) => {props.onAlphabetUpdate(id, char, index)}} colour={props.colour}/>
                     <Stack colour={props.colour}/>
                     <Visual colour={props.colour}/>

--- a/src/sim/setUp.tsx
+++ b/src/sim/setUp.tsx
@@ -5,6 +5,7 @@ type setUpProps = {
   colour: String,
   input: string,
   stacks: string[],
+  alphabet: {[id: string]: string[]},
   onInputUpdate: Function
 }
 
@@ -16,7 +17,7 @@ export const SetUp = (props: setUpProps) => {
       if (e.key === 'Enter') {
         let simInput = input
         if (options['bookendInput'].value) {
-          simInput = options['inputFrontChar'].value + input + options['inputEndChar'].value
+          simInput = props.alphabet['startChar'] + input + props.alphabet['endChar']
         }
         props.onInputUpdate(simInput)
       }
@@ -26,7 +27,7 @@ export const SetUp = (props: setUpProps) => {
     <div className={props.colour + ' simSetUpWrapper'}>
         <h1 className={props.colour + ' txtTransitionHeader'}>Simulation</h1>
         <div className={props.colour + ' inputsWrapper'}>
-          <div className={props.colour + ' simLabel'}>{'Input: ' + (options['bookendInput'].value ? options['inputFrontChar'].value : '')}<input type='text' className={props.colour + ' textInput'} onChange={(e) => {setInput(e.currentTarget.value)}} onKeyDown={(e) => {handleInput(e)}} />{(options['bookendInput'].value ? options['inputEndChar'].value : '')}</div>
+          <div className={props.colour + ' simLabel'}>{'Input: ' + (options['bookendInput'].value ? props.alphabet['startChar'] : '')}<input type='text' className={props.colour + ' textInput'} onChange={(e) => {setInput(e.currentTarget.value)}} onKeyDown={(e) => {handleInput(e)}} />{(options['bookendInput'].value ? props.alphabet['endChar'] : '')}</div>
           <div className={props.colour + ' simLabel'}>{'Initial Stack: ' + props.stacks[0][0]}</div>
         </div>
     </div>

--- a/src/sim/wrapper.tsx
+++ b/src/sim/wrapper.tsx
@@ -9,8 +9,9 @@ type WrapperProps = {
     input: string,
     stacks: string[],
     currentTraversals: Traversal[],
-    states: State[]
-    haltCond: boolean
+    states: State[],
+    haltCond: boolean,
+    alphabet: {[id: string]: string[]},
     onInputUpdate: Function,
     onRun: Function,
     onStep: Function,
@@ -26,6 +27,7 @@ export const Wrapper = (props: WrapperProps) => {
         colour={props.colour}
         input={props.input}
         stacks={props.stacks}
+        alphabet={props.alphabet}
         onInputUpdate={(value: string) => {props.onInputUpdate(value)}}
         />
         <Buttons

--- a/src/txt/alphabet.tsx
+++ b/src/txt/alphabet.tsx
@@ -17,7 +17,7 @@ export const Alphabet = (props: AlphabetProps) => {
     
 
     const addChar = (id: string) => {
-        props.onAlphabetUpdate(id, '', -1)
+        props.onAlphabetUpdate(id, '#', -1)
     }
 
     return (

--- a/src/txt/alphabet.tsx
+++ b/src/txt/alphabet.tsx
@@ -2,54 +2,22 @@ import React, { useContext, useState } from 'react'
 import { Alphabet as AlphabetType } from '../types'
 import { OptionContext } from '../lib/OptionsContext'
 import { Character } from './character'
+import { AlphabetList } from './alphabetList'
 
 
 type AlphabetProps = {
-    alphabet: AlphabetType,
+    alphabet: {[id: string]: string[]},
     colour:string,
     onAlphabetUpdate: Function
 }
 
 export const Alphabet = (props: AlphabetProps) => {
     const options = useContext(OptionContext)
-    const [tempAlpha, setTempAlpha] = useState<AlphabetType>(props.alphabet)
-    const [tempChar, setTempChar] = useState<string>('')
+    let alphabet = props.alphabet
+    
 
-    const handleTempAlphabet = (e: string, type: number, index: number) => {
-        let newAlphabet = tempAlpha
-        
-        newAlphabet.allChars[index] = e
-        switch (type) {
-        case 0:
-            newAlphabet.miscChars[index] = e
-            break;
-        case 1:
-            newAlphabet.callChars[index] = e
-            break;
-        case 2:
-            newAlphabet.returnChars[index] = e
-            break;
-        case 3:
-            newAlphabet.internalChars[index] = e
-            break;
-        case 4:
-            newAlphabet.startChar = e
-            break;
-        case 5:
-            newAlphabet.endChar = e
-            break;
-        
-        default:
-            break;
-        }
-        console.log(String(e))
-        setTempAlpha(newAlphabet)
-    }
-
-    const handleAlphabet = (e: any, type: number, char: string, index: number) => {
-        if (e.key === 'Enter') {
-            props.onAlphabetUpdate(type, char, index)
-          }
+    const addChar = (id: string) => {
+        props.onAlphabetUpdate(id, '', -1)
     }
 
     return (
@@ -59,28 +27,20 @@ export const Alphabet = (props: AlphabetProps) => {
                 {(options['bookendInput'].value === true) && 
                 <div className='bookendWrapper'>
                     <div className='bookendInput'>
-                        start: <Character char={options['inputFrontChar'].value} colour={props.colour} handleAlphabet={(e: any, char: string) => {handleAlphabet(e, 4, char, 0)}}/>
+                        Start: <Character char={alphabet['startChar'][0]} colour={props.colour} handleAlphabet={(char: string) => {props.onAlphabetUpdate('startChar', char, 0)}}/>
                     </div>
                     <div className='bookendInput'>
-                        end: <Character char={options['inputEndChar'].value} colour={props.colour} handleAlphabet={(e: any, char: string) => {handleAlphabet(e, 5, char, 1)}}/>
+                        End: <Character char={alphabet['endChar'][0]} colour={props.colour} handleAlphabet={(char: string) => {props.onAlphabetUpdate('endChar', char, 0)}}/>
                     </div>
                 </div>
                 }
                 {options['forceVisibly'].value ? 
                 <>
-                <div className='alphabet'>
-                    Call: {props.alphabet.callChars.map((x, i) => {return (<Character char={x} colour={props.colour} handleAlphabet={(e: any, char: string) => {handleAlphabet(e, 0, char, i + 2 + props.alphabet.miscChars.length)}}/>)})}
-                </div>
-                <div className='alphabet'>
-                    Return: {props.alphabet.returnChars.map((x, i) => {return (<Character char={x} colour={props.colour} handleAlphabet={(e: any, char: string) => {handleAlphabet(e, 0, char, i + 2 + props.alphabet.miscChars.length + props.alphabet.callChars.length)}}/>)})}
-                </div>
-                <div className='alphabet'>
-                    Internal: {props.alphabet.internalChars.map((x, i) => {return (<Character char={x} colour={props.colour} handleAlphabet={(e: any, char: string) => {handleAlphabet(e, 0, char, i + 2 + props.alphabet.miscChars.length + props.alphabet.callChars.length + props.alphabet.returnChars.length)}}/>)})}
-                </div>
+                <AlphabetList label={'Call: '} list={alphabet['callChar']} colour={props.colour} handleAlphabet={(char: string, index: number) => {props.onAlphabetUpdate('callChar', char, index)}} addChar={() => {addChar('callChar')}}/>
+                <AlphabetList label={'Return: '} list={alphabet['returnChar']} colour={props.colour} handleAlphabet={(char: string, index: number) => {props.onAlphabetUpdate('returnChar', char, index)}} addChar={() => {addChar('returnChar')}}/>
+                <AlphabetList label={'Internal: '} list={alphabet['internalChar']} colour={props.colour} handleAlphabet={(char: string, index: number) => {props.onAlphabetUpdate('internalChar', char, index)}} addChar={() => {addChar('internalChar')}}/>
                 </> : 
-                <div className='alphabet'>
-                    {tempAlpha.miscChars.map((x, i) => {return (<Character char={x} colour={props.colour} handleAlphabet={(e: any, char: string) => {handleAlphabet(e, 0, char, i + 2)}}/>)})}
-                </div>
+                <AlphabetList label={''} list={alphabet['miscChar']} colour={props.colour} handleAlphabet={(char: string, index: number) => {props.onAlphabetUpdate('miscChar', char, index)}} addChar={() => {addChar('miscChar')}}/>
                 }
             </div>
         </div>

--- a/src/txt/alphabet.tsx
+++ b/src/txt/alphabet.tsx
@@ -1,14 +1,56 @@
-import React, { useContext } from 'react'
+import React, { useContext, useState } from 'react'
 import { Alphabet as AlphabetType } from '../types'
 import { OptionContext } from '../lib/OptionsContext'
+import { Character } from './character'
+
 
 type AlphabetProps = {
     alphabet: AlphabetType,
-    colour:string
+    colour:string,
+    onAlphabetUpdate: Function
 }
 
 export const Alphabet = (props: AlphabetProps) => {
     const options = useContext(OptionContext)
+    const [tempAlpha, setTempAlpha] = useState<AlphabetType>(props.alphabet)
+    const [tempChar, setTempChar] = useState<string>('')
+
+    const handleTempAlphabet = (e: string, type: number, index: number) => {
+        let newAlphabet = tempAlpha
+        
+        newAlphabet.allChars[index] = e
+        switch (type) {
+        case 0:
+            newAlphabet.miscChars[index] = e
+            break;
+        case 1:
+            newAlphabet.callChars[index] = e
+            break;
+        case 2:
+            newAlphabet.returnChars[index] = e
+            break;
+        case 3:
+            newAlphabet.internalChars[index] = e
+            break;
+        case 4:
+            newAlphabet.startChar = e
+            break;
+        case 5:
+            newAlphabet.endChar = e
+            break;
+        
+        default:
+            break;
+        }
+        console.log(String(e))
+        setTempAlpha(newAlphabet)
+    }
+
+    const handleAlphabet = (e: any, type: number, char: string, index: number) => {
+        if (e.key === 'Enter') {
+            props.onAlphabetUpdate(type, char, index)
+          }
+    }
 
     return (
         <div id='txtAlphabetWrapper' className={props.colour}>
@@ -17,27 +59,27 @@ export const Alphabet = (props: AlphabetProps) => {
                 {(options['bookendInput'].value === true) && 
                 <div className='bookendWrapper'>
                     <div className='bookendInput'>
-                        start: <input type='input' className={props.colour + ' boxInput'} maxLength={1}/>
+                        start: <Character char={options['inputFrontChar'].value} colour={props.colour} handleAlphabet={(e: any, char: string) => {handleAlphabet(e, 4, char, 0)}}/>
                     </div>
                     <div className='bookendInput'>
-                        end: <input type='input' className={props.colour + ' boxInput'} maxLength={1}/>
+                        end: <Character char={options['inputEndChar'].value} colour={props.colour} handleAlphabet={(e: any, char: string) => {handleAlphabet(e, 5, char, 1)}}/>
                     </div>
                 </div>
                 }
                 {options['forceVisibly'].value ? 
                 <>
                 <div className='alphabet'>
-                    Call: {props.alphabet.callChars.map((x, i) => {return x + ", "})} <input type='input' className={props.colour + ' boxInput'} maxLength={1}/>
+                    Call: {props.alphabet.callChars.map((x, i) => {return (<Character char={x} colour={props.colour} handleAlphabet={(e: any, char: string) => {handleAlphabet(e, 0, char, i + 2 + props.alphabet.miscChars.length)}}/>)})}
                 </div>
                 <div className='alphabet'>
-                    Return: {props.alphabet.returnChars.map((x, i) => {return x + ", "})} <input type='input' className={props.colour + ' boxInput'} maxLength={1}/>
+                    Return: {props.alphabet.returnChars.map((x, i) => {return (<Character char={x} colour={props.colour} handleAlphabet={(e: any, char: string) => {handleAlphabet(e, 0, char, i + 2 + props.alphabet.miscChars.length + props.alphabet.callChars.length)}}/>)})}
                 </div>
                 <div className='alphabet'>
-                    Internal: {props.alphabet.internalChars.map((x, i) => {return x + ", "})} <input type='input' className={props.colour + ' boxInput'} maxLength={1}/>
+                    Internal: {props.alphabet.internalChars.map((x, i) => {return (<Character char={x} colour={props.colour} handleAlphabet={(e: any, char: string) => {handleAlphabet(e, 0, char, i + 2 + props.alphabet.miscChars.length + props.alphabet.callChars.length + props.alphabet.returnChars.length)}}/>)})}
                 </div>
                 </> : 
                 <div className='alphabet'>
-                    {props.alphabet.miscChars.map((x, i) => {return x + ", "})} <input type='input' className={props.colour + ' boxInput'} maxLength={1}/>
+                    {tempAlpha.miscChars.map((x, i) => {return (<Character char={x} colour={props.colour} handleAlphabet={(e: any, char: string) => {handleAlphabet(e, 0, char, i + 2)}}/>)})}
                 </div>
                 }
             </div>

--- a/src/txt/alphabet.tsx
+++ b/src/txt/alphabet.tsx
@@ -1,0 +1,46 @@
+import React, { useContext } from 'react'
+import { Alphabet as AlphabetType } from '../types'
+import { OptionContext } from '../lib/OptionsContext'
+
+type AlphabetProps = {
+    alphabet: AlphabetType,
+    colour:string
+}
+
+export const Alphabet = (props: AlphabetProps) => {
+    const options = useContext(OptionContext)
+
+    return (
+        <div id='txtAlphabetWrapper' className={props.colour}>
+            <h1 className={props.colour + ' txtAlphabetHeader'}>Alphabet</h1>
+            <div className={props.colour + ' listWrapper'}>
+                {(options['bookendInput'].value === true) && 
+                <div className='bookendWrapper'>
+                    <div className='bookendInput'>
+                        start: <input type='input' className={props.colour + ' boxInput'} maxLength={1}/>
+                    </div>
+                    <div className='bookendInput'>
+                        end: <input type='input' className={props.colour + ' boxInput'} maxLength={1}/>
+                    </div>
+                </div>
+                }
+                {options['forceVisibly'].value ? 
+                <>
+                <div className='alphabet'>
+                    Call: {props.alphabet.callChars.map((x, i) => {return x + ", "})} <input type='input' className={props.colour + ' boxInput'} maxLength={1}/>
+                </div>
+                <div className='alphabet'>
+                    Return: {props.alphabet.returnChars.map((x, i) => {return x + ", "})} <input type='input' className={props.colour + ' boxInput'} maxLength={1}/>
+                </div>
+                <div className='alphabet'>
+                    Internal: {props.alphabet.internalChars.map((x, i) => {return x + ", "})} <input type='input' className={props.colour + ' boxInput'} maxLength={1}/>
+                </div>
+                </> : 
+                <div className='alphabet'>
+                    {props.alphabet.miscChars.map((x, i) => {return x + ", "})} <input type='input' className={props.colour + ' boxInput'} maxLength={1}/>
+                </div>
+                }
+            </div>
+        </div>
+    )
+}

--- a/src/txt/alphabetList.tsx
+++ b/src/txt/alphabetList.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react"
+import { Character } from "./character"
+
+type AlphabetListProps = {
+    label : string,
+    list : string[],
+    colour : string,
+    handleAlphabet : Function,
+    addChar : Function
+}
+
+export const AlphabetList = (props: AlphabetListProps) => {
+    let aList = props.list
+    let elems = aList.map((x, i) => {
+        return (
+        <><Character 
+            char={x}
+            colour={props.colour}
+            handleAlphabet={(char: string) => {props.handleAlphabet(char, i)}}/> ,</>
+        )})
+
+    const handleAddChar = () => {
+        props.addChar()
+    }
+
+    return (
+        <div className='alphabet'>
+            {props.label}
+            {elems}
+            <button className={props.colour + ' charAdd'} title={'Add new character'} onClick={() => {handleAddChar()}}>+</button>
+        </div>
+        )
+}

--- a/src/txt/character.tsx
+++ b/src/txt/character.tsx
@@ -8,5 +8,12 @@ type CharacterProps = {
 
 export const Character = (props: CharacterProps) => {
     const [char, setChar] = useState<string>(props.char)
-    return (<input type='input' className={props.colour + ' boxInput'} maxLength={1} value={char} onChange={(e) => setChar(e.currentTarget.value)} onKeyDown={(e) => {props.handleAlphabet(e, char)}}/>)
+
+    const handleCharChange = (e: any) => {
+        if (e.key === 'Enter') {
+            props.handleAlphabet(char)
+        }
+    }
+
+    return (<input type='input' className={props.colour + ' boxInput'} maxLength={1} value={char} onChange={(e) => setChar(e.currentTarget.value)} onKeyDown={(e) => {handleCharChange(e)}}/>)
 }

--- a/src/txt/character.tsx
+++ b/src/txt/character.tsx
@@ -1,0 +1,12 @@
+import React, { useState } from 'react'
+
+type CharacterProps = {
+    char: string,
+    colour:string,
+    handleAlphabet:Function
+}
+
+export const Character = (props: CharacterProps) => {
+    const [char, setChar] = useState<string>(props.char)
+    return (<input type='input' className={props.colour + ' boxInput'} maxLength={1} value={char} onChange={(e) => setChar(e.currentTarget.value)} onKeyDown={(e) => {props.handleAlphabet(e, char)}}/>)
+}

--- a/src/txt/transition.tsx
+++ b/src/txt/transition.tsx
@@ -30,10 +30,8 @@ export default function TransitionComponent(props: TransitionProps) {
     const options = useContext(OptionContext)
 
     const handleCInput= (e: any) => {
-        if (e.key === 'Enter') {
-            props.onCInputUpdate(transition.id, cInput)
-            setCInput(props.transition.cInput)
-        }
+        props.onCInputUpdate(transition.id, e)
+        setCInput(e)
     }
 
     const handleCState = (e: any) => {
@@ -94,7 +92,7 @@ export default function TransitionComponent(props: TransitionProps) {
     <div id={'transition' + transition.id} className={props.colour + ' transition show'}>
         <input id='removeTransition' title={'Remove transition'} type= 'submit' className={props.colour + ' remove'} value='&times;' onClick={() => {props.onRemove(transition.id)}}/>
         <input id='currentState' title={'State at start of transition'} type='input' className={props.colour + ' boxInput'} value={cState} onChange={(e) => setCState(e.currentTarget.value)} onKeyDown={(e) => handleCState(e)}/>
-        <select id='currentInput' title={'Input at start of transition'} className={props.colour + ' boxInput'} value={cInput} onChange={(e) => setCInput(e.currentTarget.value)} onKeyDown={(e) => handleCInput(e)}>
+        <select id='currentInput' title={'Input at start of transition'} className={props.colour + ' boxSelect'} value={cInput} onChange={(e) => handleCInput(e.currentTarget.value)} >
             {props.alphabet['allChar'].map((x, i) => {return(
                 <option key={i} value={x}>{x}</option>
             )})}

--- a/src/txt/transition.tsx
+++ b/src/txt/transition.tsx
@@ -30,8 +30,10 @@ export default function TransitionComponent(props: TransitionProps) {
     const options = useContext(OptionContext)
 
     const handleCInput= (e: any) => {
-        props.onCInputUpdate(transition.id, e)
-        setCInput(e)
+        if (e !== '') {
+            props.onCInputUpdate(transition.id, e)
+            setCInput(e)
+        }
     }
 
     const handleCState = (e: any) => {
@@ -93,6 +95,7 @@ export default function TransitionComponent(props: TransitionProps) {
         <input id='removeTransition' title={'Remove transition'} type= 'submit' className={props.colour + ' remove'} value='&times;' onClick={() => {props.onRemove(transition.id)}}/>
         <input id='currentState' title={'State at start of transition'} type='input' className={props.colour + ' boxInput'} value={cState} onChange={(e) => setCState(e.currentTarget.value)} onKeyDown={(e) => handleCState(e)}/>
         <select id='currentInput' title={'Input at start of transition'} className={props.colour + ' boxSelect'} value={cInput} onChange={(e) => handleCInput(e.currentTarget.value)} >
+            <option key={-1} value={''}></option>
             {props.alphabet['allChar'].map((x, i) => {return(
                 <option key={i} value={x}>{x}</option>
             )})}

--- a/src/txt/transition.tsx
+++ b/src/txt/transition.tsx
@@ -10,6 +10,7 @@ type TransitionProps = {
     nState: string,
     colour: string,
     stackCount: number,
+    alphabet: {[id: string]: string[]},
     onRemove: Function,
     onCInputUpdate: Function,
     onCStateUpdate: Function,
@@ -93,7 +94,11 @@ export default function TransitionComponent(props: TransitionProps) {
     <div id={'transition' + transition.id} className={props.colour + ' transition show'}>
         <input id='removeTransition' title={'Remove transition'} type= 'submit' className={props.colour + ' remove'} value='&times;' onClick={() => {props.onRemove(transition.id)}}/>
         <input id='currentState' title={'State at start of transition'} type='input' className={props.colour + ' boxInput'} value={cState} onChange={(e) => setCState(e.currentTarget.value)} onKeyDown={(e) => handleCState(e)}/>
-        <input id='currentInput' title={'Input at start of transition'} type='input' className={props.colour + ' boxInput'} value={cInput} maxLength={1} onChange={(e) => setCInput(e.currentTarget.value)} onKeyDown={(e) => handleCInput(e)}/>
+        <select id='currentInput' title={'Input at start of transition'} className={props.colour + ' boxInput'} value={cInput} onChange={(e) => setCInput(e.currentTarget.value)} onKeyDown={(e) => handleCInput(e)}>
+            {props.alphabet['allChar'].map((x, i) => {return(
+                <option key={i} value={x}>{x}</option>
+            )})}
+        </select>
         {cStack.map((x, i) => {
             if (i < props.stackCount) {
                 return (<input key={i} id={'currentStack' + i} title={'Popped Value of Stack ' + Number(i + 1) + ' at start of transition'} type='input' className={props.colour + ' boxInput'} value={x}  maxLength={1} onChange={(e) => updateCStack(e.currentTarget.value, i)} onKeyDown={(e) => handleCStack(e, i)}/>)

--- a/src/txt/transitions.tsx
+++ b/src/txt/transitions.tsx
@@ -8,6 +8,7 @@ type TransitionsProps = {
     transitions: Transition[],
     states: State[],
     stackCount: number,
+    alphabet: {[id: string]: string[]},
     colour: string,
     onRemove: Function,
     onCInputUpdate: Function,
@@ -57,6 +58,7 @@ export const Transitions = (props: TransitionsProps) => {
             nState={nState}
             colour={props.colour}
             stackCount={props.stackCount}
+            alphabet={props.alphabet}
             onRemove={(id: number) => {removeTransition(id)}}
             onCInputUpdate={(id: number, value: string) => {props.onCInputUpdate(id, value)}}
             onCStateUpdate={(id: number, name: string) => {props.onCStateUpdate(id, name)}}

--- a/src/txt/wrapper.tsx
+++ b/src/txt/wrapper.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { Transitions } from './transitions'
-import { State, Transition } from '../types'
+import { Alphabet as AlphabetType, State, Transition } from '../types'
 import { States } from './states'
 import { Alphabet } from './alphabet'
 
@@ -9,6 +9,7 @@ type WrapperProps = {
     states: State[],
     stackCount: number,
     colour: string,
+    alphabet: AlphabetType,
     onRemoveTransition: Function,
     onCInputUpdate: Function,
     onCStateUpdate: Function,
@@ -22,7 +23,8 @@ type WrapperProps = {
     onInitUpdate: Function,
     onAcceptUpdate: Function,
     onAlternateUpdate: Function,
-    onAddState: Function
+    onAddState: Function,
+    onAlphabetUpdate: Function
 }
 
 export const Wrapper = (props: WrapperProps) => {
@@ -74,7 +76,8 @@ export const Wrapper = (props: WrapperProps) => {
                 />
                 <Alphabet 
                 colour={props.colour}
-                alphabet={{startChar:'A', endChar:'B', callChars:[], returnChars:[], internalChars:[], miscChars:['C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T'], allChars:['A', 'B', 'C', 'D']}}
+                alphabet={props.alphabet}
+                onAlphabetUpdate={(type: number, char: string, oldChar: string) => {props.onAlphabetUpdate(type, char, oldChar)}}
                 />
                 </div>
             ) : (<></>)

--- a/src/txt/wrapper.tsx
+++ b/src/txt/wrapper.tsx
@@ -55,6 +55,7 @@ export const Wrapper = (props: WrapperProps) => {
                 transitions={transitions}
                 states={states}
                 stackCount={props.stackCount}
+                alphabet={alphabet}
                 colour={props.colour}
                 onRemove={(id: number) => {props.onRemoveTransition(id)}}
                 onCInputUpdate={(id: number, value: string) => {props.onCInputUpdate(id, value)}}

--- a/src/txt/wrapper.tsx
+++ b/src/txt/wrapper.tsx
@@ -9,7 +9,7 @@ type WrapperProps = {
     states: State[],
     stackCount: number,
     colour: string,
-    alphabet: AlphabetType,
+    alphabet: {[id: string]: string[]},
     onRemoveTransition: Function,
     onCInputUpdate: Function,
     onCStateUpdate: Function,
@@ -30,6 +30,7 @@ type WrapperProps = {
 export const Wrapper = (props: WrapperProps) => {
     let transitions = props.transitions
     let states = props.states
+    let alphabet = props.alphabet
 
     const [visible, setVisible] = useState<boolean>(true)
     const [render, setRender] = useState<boolean>(true)
@@ -76,8 +77,8 @@ export const Wrapper = (props: WrapperProps) => {
                 />
                 <Alphabet 
                 colour={props.colour}
-                alphabet={props.alphabet}
-                onAlphabetUpdate={(type: number, char: string, oldChar: string) => {props.onAlphabetUpdate(type, char, oldChar)}}
+                alphabet={alphabet}
+                onAlphabetUpdate={(id: string, char: string, index: number) => {props.onAlphabetUpdate(id, char, index)}}
                 />
                 </div>
             ) : (<></>)

--- a/src/txt/wrapper.tsx
+++ b/src/txt/wrapper.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { Transitions } from './transitions'
 import { State, Transition } from '../types'
 import { States } from './states'
+import { Alphabet } from './alphabet'
 
 type WrapperProps = {
     transitions: Transition[],
@@ -70,6 +71,10 @@ export const Wrapper = (props: WrapperProps) => {
                 onAcceptUpdate={(id: number, value: boolean) => {props.onAcceptUpdate(id, value)}}
                 onAlternateUpdate={(id: number, value: boolean) => {props.onAlternateUpdate(id, value)}}
                 onAdd={() => {props.onAddState()}}
+                />
+                <Alphabet 
+                colour={props.colour}
+                alphabet={{startChar:'A', endChar:'B', callChars:[], returnChars:[], internalChars:[], miscChars:['C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T'], allChars:['A', 'B', 'C', 'D']}}
                 />
                 </div>
             ) : (<></>)

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,16 @@ export type Transition = {
     nInputHead: number
 }
 
+export type Alphabet = {
+    startChar: string | undefined,
+    endChar: string | undefined,
+    callChars: string[],
+    returnChars: string[],
+    internalChars: string[],
+    miscChars: string[],
+    allChars: string[]
+}
+
 export type RegularPA = {
     states: State[]
     transitions: Transition[]

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,8 +22,8 @@ export type Transition = {
 }
 
 export type Alphabet = {
-    startChar: string | undefined,
-    endChar: string | undefined,
+    startChar: string,
+    endChar: string,
     callChars: string[],
     returnChars: string[],
     internalChars: string[],


### PR DESCRIPTION
### A dedicated window has been created for the purpose of having the user explicitly define the alphabet

- Input characters must now be first added to the alphabet before the automaton can use characters
- The Alphabet is split up into subsets depending on behaviour
- Bookend inputs are now moved from options to the txt panel
- Transitions now use a dropdown to select inputs, in order to keep inputs consistent
- Transitions for Visibly Pushdown Automata will now automatically update the values they push to the stack depending on what alphabet the input character belongs to